### PR TITLE
Add "smart caching" to irods-build image

### DIFF
--- a/Dockerfile.jenkins
+++ b/Dockerfile.jenkins
@@ -4,7 +4,7 @@ USER root
 RUN apt-get update -qq && apt-get install -y --no-install-recommends apt-utils &&\
     DEBIAN_FRONTEND=noninteractive &&\
     apt-get install -y python-pip &&\
-    pip install docker
+    pip install docker pygithub
 
 RUN apt-get install -qqy apt-transport-https ca-certificates curl gnupg2 software-properties-common && \
     curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \

--- a/irods_docker_files/build_irods.py
+++ b/irods_docker_files/build_irods.py
@@ -5,12 +5,35 @@ from __future__ import print_function
 import configuration
 import argparse
 import subprocess
+import sys
+
+from github import Github
+
+if sys.version_info < (3, 0):
+    from urlparse import urlparse
+else:
+    from urllib.parse import urlparse
+
+# Dereference commitish (branch name, SHA, partial SHA, etc.) to a full SHA
+def get_sha_from_commitish(_repo, _commitish):
+    try:
+        repo = urlparse(_repo).path.strip('/')
+        return Github().get_repo(repo).get_commit(_commitish).sha
+    except:
+        print("Error getting SHA from repo [{0}] for commitish [{1}]. Please make sure URL and commitish are correct.".format(_repo, _commitish))
+        print(sys.exc_info()[0], ': ', sys.exc_info()[1])
+        return _commitish
 
 def build_irods_in_containers(base_os, build_id, irods_repo, irods_commitish, icommands_repo, icommands_commitish, output_directory):
     build_tag = base_os +'-irods-build:' + build_id
     print(build_tag)
     base_image = base_os + ':' + build_id 
-    docker_cmd = ['docker build -t {0} --build-arg base_image={1} --build-arg arg_irods_repo={2} --build-arg arg_irods_commitish={3} --build-arg arg_icommands_repo={4} --build-arg arg_icommands_commitish={5} -f Dockerfile.build_irods .'.format(build_tag, base_image, irods_repo, irods_commitish, icommands_repo, icommands_commitish)] 
+
+    # If SHA was built previously, cached build image will be used.
+    irods_sha = get_sha_from_commitish(irods_repo, irods_commitish)
+    icommands_sha = get_sha_from_commitish(icommands_repo, icommands_commitish)
+
+    docker_cmd = ['docker build -t {0} --build-arg base_image={1} --build-arg arg_irods_repo={2} --build-arg arg_irods_commitish={3} --build-arg arg_icommands_repo={4} --build-arg arg_icommands_commitish={5} -f Dockerfile.build_irods .'.format(build_tag, base_image, irods_repo, irods_sha, icommands_repo, icommands_sha)]
     print(docker_cmd)
     run_build = subprocess.check_call(docker_cmd, shell=True)
     save_irods_build(build_tag, output_directory)


### PR DESCRIPTION
Allows irods-build-and-test-workflow to selectively use cached irods-build
images based on git commit resolution. This means that branch names can be
used for the commitish field when running tests and the image will rebuild
or not depending on if the commit's SHA at the branch head changed.

NOTE: This change will break your Jenkins instance unless you install the
pygithub pip package in your running instance or rebuild the Jenkins image
and re-push to the registry.