### PR TITLE
[#54] Add option to skip unit tests to run_tests.py

### DIFF
--- a/irods_docker_files/run_tests_in_parallel.py
+++ b/irods_docker_files/run_tests_in_parallel.py
@@ -151,8 +151,9 @@ def main():
     # Add unit-test commands to the list.
     docker_cmds_list = []
     irods_sha = ci_utilities.get_sha_from_commitish(args.irods_repo, args.irods_commitish)
-    test_list = download_list_of_tests(args.irods_repo, irods_sha, 'unit_tests/unit_tests_list.json')
-    docker_cmds_list.extend(to_docker_commands(test_list, args, args.is_unit_test))
+    if args.is_unit_test:
+        test_list = download_list_of_tests(args.irods_repo, irods_sha, 'unit_tests/unit_tests_list.json')
+        docker_cmds_list.extend(to_docker_commands(test_list, args, args.is_unit_test))
 
     # Add core-test commands to the list.
     test_list = download_list_of_tests(args.irods_repo, irods_sha, 'scripts/core_tests_list.json')

--- a/jenkins_home/jobs/irods-build-and-test-workflow/config.xml
+++ b/jenkins_home/jobs/irods-build-and-test-workflow/config.xml
@@ -46,6 +46,11 @@
           <defaultValue>true</defaultValue>
         </hudson.model.BooleanParameterDefinition>
         <hudson.model.BooleanParameterDefinition>
+          <name>PARAMETER_RUN_CORE_UNIT_TESTS</name>
+          <description>Run unit tests for iRODS core.</description>
+          <defaultValue>true</defaultValue>
+        </hudson.model.BooleanParameterDefinition>
+        <hudson.model.BooleanParameterDefinition>
           <name>PARAMETER_RUN_PLUGIN_TESTS</name>
           <description></description>
           <defaultValue>true</defaultValue>
@@ -81,7 +86,7 @@
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
-  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2.76">
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2.77">
     <script>node {
     def job_number = env.BUILD_ID
     def buildOutputDirectory = env.JENKINS_OUTPUT + &apos;/build_irods_on_base/&apos; + job_number
@@ -116,7 +121,8 @@
                     [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IRODS_REPO&apos;, value: PARAMETER_IRODS_REPO],
                     [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IRODS_COMMITISH&apos;, value: PARAMETER_IRODS_COMMITISH],
                     [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_TEST_PARALLELISM&apos;, value: PARAMETER_TEST_PARALLELISM],
-                    [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_EXTERNALS_ROOT_DIR&apos;, value: PARAMETER_EXTERNALS_ROOT_DIR]
+                    [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_EXTERNALS_ROOT_DIR&apos;, value: PARAMETER_EXTERNALS_ROOT_DIR],
+                    [$class: &apos;BooleanParameterValue&apos;, name: &apos;PARAMETER_RUN_UNIT_TESTS&apos;, value: PARAMETER_RUN_CORE_UNIT_TESTS]
                 ]
             }    
         }

--- a/jenkins_home/jobs/run_irods_tests/config.xml
+++ b/jenkins_home/jobs/run_irods_tests/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.1' encoding='UTF-8'?>
-<flow-definition plugin="workflow-job@2.32">
+<flow-definition plugin="workflow-job@2.36">
   <actions/>
   <description></description>
   <keepDependencies>false</keepDependencies>
@@ -58,10 +58,15 @@
           <defaultValue>4</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.BooleanParameterDefinition>
+          <name>PARAMETER_RUN_UNIT_TESTS</name>
+          <description></description>
+          <defaultValue>true</defaultValue>
+        </hudson.model.BooleanParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
-  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2.70">
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2.77">
     <script>node {
      def build_id = env.BUILD_ID
      if(!PARAMETER_PARENT_JOB_ID.equals(&apos;&apos;)) {
@@ -86,6 +91,9 @@
                                                  &apos; --irods_commitish &apos; + PARAMETER_IRODS_COMMITISH +
                                                  &apos; --test_parallelism &apos; + PARAMETER_TEST_PARALLELISM +
                                                  &apos; --externals_dir &apos; + PARAMETER_EXTERNALS_ROOT_DIR
+                if (PARAMETER_RUN_UNIT_TESTS == &quot;false&quot;) {
+                    run_cmd = run_cmd + &apos; --skip_unit_tests&apos;
+                }
                 parallelBranches[&quot;${os}&quot;] = {
                     sh run_cmd 
                 }


### PR DESCRIPTION
#54 is specifically about creating a new pipeline step for full separation, but this change simply allows for the Jenkins user to uncheck a box to elide core unit tests. This may be useful in the future for plugin tests should they ever grow the ability to run unit tests.