### PR TITLE
[#29] Parameterize mysql odbc connector files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **.swp
 **.un
 jenkins_output/*
+tags

--- a/irods_docker_files/Dockerfile.fed
+++ b/irods_docker_files/Dockerfile.fed
@@ -17,6 +17,7 @@ COPY mysql_other_zone.input /mysql_other_zone.input
 COPY zones.json /zones.json
 COPY get_irods_version.py /
 COPY ci_utilities.py /ci_utilities.py
+COPY configuration.py /configuration.py
 
 ADD run_tests_in_zone.py /
 RUN chmod u+x /run_tests_in_zone.py

--- a/irods_docker_files/Dockerfile.install_and_test
+++ b/irods_docker_files/Dockerfile.install_and_test
@@ -16,6 +16,7 @@ ADD install_externals.py /
 RUN chmod u+x /install_externals.py
 
 COPY ci_utilities.py /
+COPY configuration.py /
 
 RUN echo export IRODS_ENABLE_TEST_MODE="1" > /etc/profile.d/irods.sh
 RUN chmod 644 /etc/profile.d/irods.sh

--- a/irods_docker_files/Dockerfile.topo
+++ b/irods_docker_files/Dockerfile.topo
@@ -15,6 +15,7 @@ RUN chmod u+x /setup_database_client.py
 
 COPY install_externals.py /install_externals.py
 COPY ci_utilities.py /ci_utilities.py
+COPY configuration.py /configuration.py
 COPY irods_consumer.input /irods_consumer.input
 COPY enable_ssl.py /enable_ssl.py
 

--- a/irods_docker_files/ci_utilities.py
+++ b/irods_docker_files/ci_utilities.py
@@ -16,6 +16,8 @@ except ImportError:
 from github import Github
 from subprocess import Popen, PIPE
 
+import configuration
+
 # Dereference commitish (branch name, SHA, partial SHA, etc.) to a full SHA
 def get_sha_from_commitish(_repo, _commitish):
     try:
@@ -357,3 +359,15 @@ stdout: {3}
 stderr: {4}
 '''.format(args, kwargs, p.returncode, out, err))
     return p.returncode, out, err
+
+def get_path_to_mysql_odbc_connector(distribution_name, distribution_version_major, dirname):
+    key = '_'.join([distribution_name, distribution_version_major])
+    filename = '.'.join([configuration.mysql_odbc_connectors[key], 'tar', 'gz'])
+    return os.path.join(dirname, filename)
+
+def get_mysql_odbc_connector_volume_mount_string(distribution_name, distribution_version_major, dirname):
+    mysql_odbc_connector_dirname = '/mysql_odbc_connectors'
+    path_to_file_on_host = get_path_to_mysql_odbc_connector(distribution_name, distribution_version_major, dirname)
+    path_to_file_in_container = get_path_to_mysql_odbc_connector(distribution_name, distribution_version_major, mysql_odbc_connector_dirname)
+    return ':'.join([path_to_file_on_host, path_to_file_in_container, 'ro'])
+

--- a/irods_docker_files/configuration.py
+++ b/irods_docker_files/configuration.py
@@ -11,3 +11,9 @@ database_dict = {
     'postgres': 'postgres:10.12',
     'oracle': 'oracle/database:11.2.0.2-xe'
 }
+
+# change this to the dirname of the mysql odbc connector archive file
+mysql_odbc_connectors = {
+    'ubuntu_16': 'mysql-connector-odbc-5.3.13-linux-ubuntu16.04-x86-64bit',
+    'ubuntu_18': 'mysql-connector-odbc-5.3.13-linux-ubuntu18.04-x86-64bit'
+}

--- a/irods_docker_files/launch_topo.py
+++ b/irods_docker_files/launch_topo.py
@@ -47,7 +47,10 @@ def create_topology(cmd_line_args, provider_tag, consumer_tag_list, machine_list
 
     run_mount = None
     externals_mount = None
-    mysql_mount = '/projects/irods/vsphere-testing/externals/mysql-connector-odbc-5.3.7-linux-ubuntu16.04-x86-64bit.tar.gz:/projects/irods/vsphere-testing/externals/mysql-connector-odbc-5.3.7-linux-ubuntu16.04-x86-64bit.tar.gz'
+
+    distribution_name = cmd_line_args.platform_target.split('_')[0]
+    distribution_version_major = cmd_line_args.platform_target.split('_')[1]
+    mysql_mount = ci_utilities.get_mysql_odbc_connector_volume_mount_string(distribution_name, distribution_version_major, cmd_line_args.mysql_odbc_connector_dir)
 
     provider_name = cmd_line_args.platform_target + '-' + cmd_line_args.test_name_prefix + '-provider'
     machine_list.append(provider_name)
@@ -164,6 +167,7 @@ def main():
     parser.add_argument('--database_type', default='postgres', help='database type', required=True)
     parser.add_argument('-o', '--output_directory', type=str, required=False)
     parser.add_argument('--use_ssl', action='store_true', default=False)
+    parser.add_argument('--mysql_odbc_connector_dir', help='path to dir on host containing MySQL ODBC connector', default='/projects/irods/vsphere-testing/externals')
     
     args = parser.parse_args()
 

--- a/irods_docker_files/launch_zones_and_test.py
+++ b/irods_docker_files/launch_zones_and_test.py
@@ -43,7 +43,10 @@ def create_federation(federation_tag_list, network_name, cmd_line_args):
     upgrade_mount = None
     run_mount = None
     externals_mount = None
-    mysql_mount = '/projects/irods/vsphere-testing/externals/mysql-connector-odbc-5.3.7-linux-ubuntu16.04-x86-64bit.tar.gz:/projects/irods/vsphere-testing/externals/mysql-connector-odbc-5.3.7-linux-ubuntu16.04-x86-64bit.tar.gz'
+
+    distribution_name = cmd_line_args.platform_target.split('_')[0]
+    distribution_version_major = cmd_line_args.platform_target.split('_')[1]
+    mysql_mount = ci_utilities.get_mysql_odbc_connector_volume_mount_string(distribution_name, distribution_version_major, cmd_line_args.mysql_odbc_connector_dir)
 
     zone1 = 'tempZone'
     zone2 = 'otherZone'
@@ -120,6 +123,7 @@ def main():
     parser.add_argument('--zones', type=int, default=2, help='number of zones in the federation')
     parser.add_argument('--database_type', default='postgres', help='database type', required=True)
     parser.add_argument('-o', '--output_directory', type=str, required=False)
+    parser.add_argument('--mysql_odbc_connector_dir', help='path to dir on host containing MySQL ODBC connector', default='/projects/irods/vsphere-testing/externals')
     
     args = parser.parse_args()
 

--- a/irods_docker_files/run_tests.py
+++ b/irods_docker_files/run_tests.py
@@ -28,6 +28,7 @@ def run_tests(image_name, irods_sha, test_name_prefix, cmd_line_args, skip_unit_
     options.append(['--irods_commitish', irods_sha])
     options.append(['--test_parallelism', cmd_line_args.test_parallelism])
     options.append(['--externals_dir', cmd_line_args.externals_dir])
+    options.append(['--mysql_odbc_connector_dir', cmd_line_args.mysql_odbc_connector_dir])
     if skip_unit_tests is False:
         options.append(['--is_unit_test'])
     if cmd_line_args.run_timing_tests:
@@ -44,7 +45,6 @@ def run_plugin_tests(image_name, plugin_sha, machine_name, plugin_name, test_nam
     results_mount = cmd_line_args.output_directory + ':/irods_test_env'
     plugin_mount = cmd_line_args.plugin_build_dir + ':/plugin_mount_dir'
     key_mount = '/projects/irods/vsphere-testing/externals/amazon_web_services-CI.keypair:/projects/irods/vsphere-testing/externals/amazon_web_services-CI.keypair'
-    mysql_mount = '/projects/irods/vsphere-testing/externals/mysql-connector-odbc-5.3.7-linux-ubuntu16.04-x86-64bit.tar.gz:/projects/irods/vsphere-testing/externals/mysql-connector-odbc-5.3.7-linux-ubuntu16.04-x86-64bit.tar.gz'
     run_mount = '/tmp/$(mktemp -d):/run'
     externals_mount = cmd_line_args.externals_dir + ':/irods_externals'
 
@@ -56,6 +56,10 @@ def run_plugin_tests(image_name, plugin_sha, machine_name, plugin_name, test_nam
         exec_cmd = centosCmdBuilder.build_exec_cmd()
         stop_cmd = centosCmdBuilder.build_stop_cmd()
     elif 'ubuntu' in machine_name:
+        distribution_name = cmd_line_args.platform_target.split('_')[0]
+        distribution_version_major = cmd_line_args.platform_target.split('_')[1]
+        mysql_mount = ci_utilities.get_mysql_odbc_connector_volume_mount_string(distribution_name, distribution_version_major, cmd_line_args.mysql_odbc_connector_dir)
+
         ubuntuCmdBuilder = DockerCommandsBuilder()
         ubuntuCmdBuilder.plugin_constructor(machine_name, build_mount, plugin_mount, results_mount, key_mount, mysql_mount, None, externals_mount, image_name, 'install_and_test.py', cmd_line_args.database_type, cmd_line_args.plugin_repo, plugin_sha, cmd_line_args.passthrough_arguments)
         
@@ -98,6 +102,7 @@ def main():
     parser.add_argument('--passthrough_arguments', type=str)
     parser.add_argument('--skip_unit_tests', action='store_true', default=False)
     parser.add_argument('--run_timing_tests', action='store_true', default=False)
+    parser.add_argument('--mysql_odbc_connector_dir', help='path to dir on host containing MySQL ODBC connector', default='/projects/irods/vsphere-testing/externals')
     
     args = parser.parse_args()
     build_tag = None

--- a/irods_docker_files/run_tests_in_parallel.py
+++ b/irods_docker_files/run_tests_in_parallel.py
@@ -39,7 +39,6 @@ def to_docker_commands(test_list, cmd_line_args, is_unit_test=False):
     results_mount = cmd_line_args.jenkins_output + ':/irods_test_env'
     run_mount = '/tmp/$(mktemp -d):/run'
     externals_mount = cmd_line_args.externals_dir + ':/irods_externals'
-    mysql_mount = '/projects/irods/vsphere-testing/externals/mysql-connector-odbc-5.3.7-linux-ubuntu16.04-x86-64bit.tar.gz:/projects/irods/vsphere-testing/externals/mysql-connector-odbc-5.3.7-linux-ubuntu16.04-x86-64bit.tar.gz'
 
     for test in test_list:
         container_name = cmd_line_args.test_name_prefix + '_' + test + '_' + cmd_line_args.database_type
@@ -56,6 +55,11 @@ def to_docker_commands(test_list, cmd_line_args, is_unit_test=False):
             exec_cmd = centosCmdBuilder.build_exec_cmd()
             stop_cmd = centosCmdBuilder.build_stop_cmd()
         elif 'ubuntu' in cmd_line_args.image_name:
+            platform = cmd_line_args.image_name.split('-')[0]
+            distribution_name = platform.split('_')[0]
+            distribution_version_major = platform.split('_')[1]
+            mysql_mount = ci_utilities.get_mysql_odbc_connector_volume_mount_string(distribution_name, distribution_version_major, cmd_line_args.mysql_odbc_connector_dir)
+
             ubuntuCmdBuilder = DockerCommandsBuilder()
             ubuntuCmdBuilder.core_constructor(container_name, build_mount, upgrade_mount, results_mount, None, externals_mount, mysql_mount, cmd_line_args.image_name, 'install_and_test.py', cmd_line_args.database_type, test, test_type, is_unit_test, True, database_container)
 
@@ -85,6 +89,7 @@ def main():
     parser.add_argument('--test_parallelism', type=str, default='4', required=True)
     parser.add_argument('--is_unit_test', action='store_true', default=False)
     parser.add_argument('--run_timing_tests', action='store_true', default=False)
+    parser.add_argument('--mysql_odbc_connector_dir', help='path to dir on host containing MySQL ODBC connector', default='/projects/irods/vsphere-testing/externals')
     args = parser.parse_args()
 
     # Add unit-test commands to the list.

--- a/irods_docker_files/setup_database.py
+++ b/irods_docker_files/setup_database.py
@@ -53,11 +53,11 @@ def configure_database(database, database_machine, provider_machine, network_nam
         #run_docker_command(['docker', 'exec', database_machine, 'mysqladmin', '--user=root', '--password=password', 'ping'])
         format_str = '{{json .NetworkSettings.Networks.' + network_name + '.IPAddress}}'
         ip_address = get_ipaddress(provider_machine, format_str).strip()
+        run_docker_command(['docker', 'exec', database_machine, 'mysql', '--user=root', '--password=password', '-e', 'drop database if exists ICAT;'])
+        run_docker_command(['docker', 'exec', database_machine, 'mysql', '--user=root', '--password=password', '-e', 'create database ICAT character set latin1 collate latin1_general_cs;'])
         run_docker_command(['docker', 'exec', database_machine, 'mysql', '--user=root', '--password=password', '-e', "CREATE USER 'irods'@{0} IDENTIFIED BY 'testpassword';".format(ip_address)])
         run_docker_command(['docker', 'exec', database_machine, 'mysql', '--user=root', '--password=password', '-e', "GRANT ALL PRIVILEGES ON ICAT.* to 'irods'@{0};".format(ip_address)])
         run_docker_command(['docker', 'exec', database_machine, 'mysql', '--user=root', '--password=password', '-e', 'FLUSH PRIVILEGES;'])
-        run_docker_command(['docker', 'exec', database_machine, 'mysql', '--user=root', '--password=password', '-e', 'drop database if exists ICAT;'])
-        run_docker_command(['docker', 'exec', database_machine, 'mysql', '--user=root', '--password=password', '-e', 'create database ICAT character set latin1 collate latin1_general_cs;'])
     elif database == 'oracle':
         pass
     else:

--- a/irods_jenkins.yml
+++ b/irods_jenkins.yml
@@ -12,7 +12,6 @@ services:
       - ./irods_docker_files:/irods_docker_files
       - ./jenkins_output:/jenkins_output
       - /projects/irods/vsphere-testing/externals/amazon_web_services-CI.keypair:/projects/irods/vsphere-testing/externals/amazon_web_services-CI.keypair
-      - /projects/irods/vsphere-testing/externals/mysql-connector-odbc-5.3.7-linux-ubuntu16.04-x86-64bit.tar.gz:/projects/irods/vsphere-testing/externals/mysql-connector-odbc-5.3.7-linux-ubuntu16.04-x86-64bit.tar.gz
       - /var/run/docker.sock:/var/run/docker.sock
     secrets:
       - jenkins-user

--- a/jenkins_home/jobs/run_irods_tests/config.xml
+++ b/jenkins_home/jobs/run_irods_tests/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.1' encoding='UTF-8'?>
-<flow-definition plugin="workflow-job@2.36">
+<flow-definition plugin="workflow-job@2.39">
   <actions/>
   <description></description>
   <keepDependencies>false</keepDependencies>
@@ -68,10 +68,16 @@
           <description></description>
           <defaultValue>false</defaultValue>
         </hudson.model.BooleanParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>PARAMETER_MYSQL_ODBC_CONNECTOR_DIR</name>
+          <description></description>
+          <defaultValue>/projects/irods/vsphere-testing/externals</defaultValue>
+          <trim>true</trim>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
-  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2.77">
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2.80">
     <script>node {
      def build_id = env.BUILD_ID
      print(build_id)
@@ -93,7 +99,8 @@
                               &apos; --irods_repo &apos; + PARAMETER_IRODS_REPO +
                               &apos; --irods_commitish &apos; + PARAMETER_IRODS_COMMITISH +
                               &apos; --test_parallelism &apos; + PARAMETER_TEST_PARALLELISM +
-                              &apos; --externals_dir &apos; + PARAMETER_EXTERNALS_ROOT_DIR
+                              &apos; --externals_dir &apos; + PARAMETER_EXTERNALS_ROOT_DIR +
+                              &apos; --mysql_odbc_connector_dir &apos; + PARAMETER_MYSQL_ODBC_CONNECTOR_DIR
                 if (PARAMETER_RUN_UNIT_TESTS == &quot;false&quot;) {
                     run_cmd = run_cmd + &apos; --skip_unit_tests&apos;
                 }

--- a/jenkins_home/jobs/run_tests_on_federation/config.xml
+++ b/jenkins_home/jobs/run_tests_on_federation/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.1' encoding='UTF-8'?>
-<flow-definition plugin="workflow-job@2.36">
+<flow-definition plugin="workflow-job@2.39">
   <actions/>
   <description></description>
   <keepDependencies>false</keepDependencies>
@@ -49,10 +49,16 @@
           <defaultValue>None</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>PARAMETER_MYSQL_ODBC_CONNECTOR_DIR</name>
+          <description></description>
+          <defaultValue>/projects/irods/vsphere-testing/externals</defaultValue>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
-  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2.77">
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2.80">
     <script>node {
      def build_id = env.BUILD_ID
      
@@ -73,7 +79,8 @@
                               &apos; -o &apos; + output_directory + 
                               &apos; --database_type &apos; + PARAMETER_DATABASE_TYPE + 
                               &apos; --test_type &apos; + PARAMETER_TEST_TYPE + 
-                              &apos; --specific_test &apos; + PARAMETER_SPECIFIC_TEST
+                              &apos; --specific_test &apos; + PARAMETER_SPECIFIC_TEST +
+                              &apos; --mysql_odbc_connector_dir &apos; + PARAMETER_MYSQL_ODBC_CONNECTOR_DIR
                 parallelBranches[&quot;${os}&quot;] = {
                     sh run_cmd 
                 }

--- a/jenkins_home/jobs/run_tests_on_topology/config.xml
+++ b/jenkins_home/jobs/run_tests_on_topology/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.1' encoding='UTF-8'?>
-<flow-definition plugin="workflow-job@2.36">
+<flow-definition plugin="workflow-job@2.39">
   <actions/>
   <description></description>
   <keepDependencies>false</keepDependencies>
@@ -55,10 +55,16 @@
           <description></description>
           <defaultValue>false</defaultValue>
         </hudson.model.BooleanParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>PARAMETER_MYSQL_ODBC_CONNECTOR_DIR</name>
+          <description></description>
+          <defaultValue>/projects/irods/vsphere-testing/externals</defaultValue>
+          <trim>false</trim>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
-  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2.77">
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2.80">
     <script>node {
      def build_id = env.BUILD_ID
      def output_directory = env.JENKINS_OUTPUT + &apos;/&apos; + env.JOB_NAME + &apos;/&apos; + build_id
@@ -78,7 +84,8 @@
                               &apos; -o &apos; + output_directory + 
                               &apos; --database_type &apos; + PARAMETER_DATABASE_TYPE + 
                               &apos; --test_type &apos; + PARAMETER_TEST_TYPE + 
-                              &apos; --specific_test &apos; + PARAMETER_SPECIFIC_TEST
+                              &apos; --specific_test &apos; + PARAMETER_SPECIFIC_TEST +
+                              &apos; --mysql_odbc_connector_dir &apos; + PARAMETER_MYSQL_ODBC_CONNECTOR_DIR
                 if(PARAMETER_ENABLE_SSL == &quot;true&quot;) {
                     run_cmd = run_cmd + &apos; --use_ssl&apos;
                 }

--- a/jenkins_home/jobs/serialized-irods-build-and-test-workflow/config.xml
+++ b/jenkins_home/jobs/serialized-irods-build-and-test-workflow/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.1' encoding='UTF-8'?>
-<flow-definition plugin="workflow-job@2.37">
+<flow-definition plugin="workflow-job@2.39">
   <actions/>
   <description></description>
   <keepDependencies>false</keepDependencies>
@@ -98,6 +98,12 @@
           <defaultValue>None</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>PARAMETER_MYSQL_ODBC_CONNECTOR_DIR</name>
+          <description></description>
+          <defaultValue>/projects/irods/vsphere-testing/externals</defaultValue>
+          <trim>true</trim>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
@@ -136,7 +142,8 @@
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IRODS_COMMITISH&apos;, value: PARAMETER_IRODS_COMMITISH],
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_TEST_PARALLELISM&apos;, value: PARAMETER_TEST_PARALLELISM],
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_EXTERNALS_ROOT_DIR&apos;, value: PARAMETER_EXTERNALS_ROOT_DIR],
-                [$class: &apos;BooleanParameterValue&apos;, name: &apos;PARAMETER_RUN_CORE_TIMING_TESTS&apos;, value: PARAMETER_RUN_CORE_TIMING_TESTS]
+                [$class: &apos;BooleanParameterValue&apos;, name: &apos;PARAMETER_RUN_CORE_TIMING_TESTS&apos;, value: PARAMETER_RUN_CORE_TIMING_TESTS],
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_MYSQL_ODBC_CONNECTOR_DIR&apos;, value: PARAMETER_MYSQL_ODBC_CONNECTOR_DIR]
             ]
         }
     }
@@ -152,7 +159,8 @@
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IRODS_COMMITISH&apos;, value: PARAMETER_IRODS_COMMITISH],
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_TEST_PARALLELISM&apos;, value: PARAMETER_TEST_PARALLELISM],
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_EXTERNALS_ROOT_DIR&apos;, value: PARAMETER_EXTERNALS_ROOT_DIR],
-                [$class: &apos;BooleanParameterValue&apos;, name: &apos;PARAMETER_RUN_UNIT_TESTS&apos;, value: PARAMETER_RUN_CORE_UNIT_TESTS]
+                [$class: &apos;BooleanParameterValue&apos;, name: &apos;PARAMETER_RUN_UNIT_TESTS&apos;, value: PARAMETER_RUN_CORE_UNIT_TESTS],
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_MYSQL_ODBC_CONNECTOR_DIR&apos;, value: PARAMETER_MYSQL_ODBC_CONNECTOR_DIR]
             ]
         }    
     }
@@ -160,10 +168,11 @@
         stage(&quot;Install and Run Federation Tests&quot;) {
             build job:&quot;run_tests_on_federation&quot;,
             parameters: [
-                    [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_PLATFORM_TARGETS&apos;, value: PARAMETER_PLATFORM_TARGETS],
-                    [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IMAGE_TAG&apos;, value: job_number],
-                    [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IRODS_BUILD_DIR&apos;, value: buildOutputDirectory],
-                    [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_DATABASE_TYPE&apos;, value: PARAMETER_DATABASE_TYPE]
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_PLATFORM_TARGETS&apos;, value: PARAMETER_PLATFORM_TARGETS],
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IMAGE_TAG&apos;, value: job_number],
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IRODS_BUILD_DIR&apos;, value: buildOutputDirectory],
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_DATABASE_TYPE&apos;, value: PARAMETER_DATABASE_TYPE],
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_MYSQL_ODBC_CONNECTOR_DIR&apos;, value: PARAMETER_MYSQL_ODBC_CONNECTOR_DIR]
             ]
         }
     }
@@ -176,24 +185,26 @@
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IMAGE_TAG&apos;, value: job_number],
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IRODS_BUILD_DIR&apos;, value: buildOutputDirectory],
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_PLUGIN_GIT_COMMITISH&apos;, value: PARAMETER_IRODS_COMMITISH],
-                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_DATABASE_TYPE&apos;, value: PARAMETER_DATABASE_TYPE]
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_DATABASE_TYPE&apos;, value: PARAMETER_DATABASE_TYPE],
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_MYSQL_ODBC_CONNECTOR_DIR&apos;, value: PARAMETER_MYSQL_ODBC_CONNECTOR_DIR]
             ]
         }  
     }
     if(PARAMETER_RUN_TOPOLOGY_ICAT_TESTS == &quot;true&quot;) {
-        stage(&quot;Install and Run Topology Tests on Provider&quot;) {
+        stage(&quot;Install and Run Topology Tests&quot;) {
             build job:&quot;run_tests_on_topology&quot;,
             parameters: [
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_PLATFORM_TARGETS&apos;, value: PARAMETER_PLATFORM_TARGETS],
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IMAGE_TAG&apos;, value: job_number],
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IRODS_BUILD_DIR&apos;, value: buildOutputDirectory],
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_DATABASE_TYPE&apos;, value: PARAMETER_DATABASE_TYPE],
-                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_TEST_TYPE&apos;, value: &apos;topology_icat&apos;]
+                [$class: &apos;ChoiceParameterValue&apos;, name: &apos;PARAMETER_TEST_TYPE&apos;, value: &apos;topology_icat&apos;],
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_MYSQL_ODBC_CONNECTOR_DIR&apos;, value: PARAMETER_MYSQL_ODBC_CONNECTOR_DIR]
             ]
         }
     }
     if(PARAMETER_RUN_TOPOLOGY_ICAT_TESTS == &quot;true&quot; &amp;&amp; PARAMETER_ENABLE_SSL == &quot;true&quot;) {
-        stage(&quot;Install and Run Topology Tests With SSL on Provider&quot;) {
+        stage(&quot;Install and Run Topology Tests With SSL&quot;) {
             build job:&quot;run_tests_on_topology&quot;,
             parameters: [
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_PLATFORM_TARGETS&apos;, value: PARAMETER_PLATFORM_TARGETS],
@@ -201,24 +212,13 @@
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IRODS_BUILD_DIR&apos;, value: buildOutputDirectory],
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_DATABASE_TYPE&apos;, value: PARAMETER_DATABASE_TYPE],
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_TEST_TYPE&apos;, value: &apos;topology_icat&apos;],
-                [$class: &apos;BooleanParameterValue&apos;, name: &apos;PARAMETER_ENABLE_SSL&apos;, value: PARAMETER_ENABLE_SSL]
+                [$class: &apos;BooleanParameterValue&apos;, name: &apos;PARAMETER_ENABLE_SSL&apos;, value: PARAMETER_ENABLE_SSL],
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_MYSQL_ODBC_CONNECTOR_DIR&apos;, value: PARAMETER_MYSQL_ODBC_CONNECTOR_DIR]
             ]
         }
     }
     if(PARAMETER_RUN_TOPOLOGY_RESOURCE_TESTS == &quot;true&quot;) {
-        stage(&quot;Install and Run Topology Tests on Consumer&quot;) {
-            build job:&quot;run_tests_on_topology&quot;,
-            parameters: [
-                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_PLATFORM_TARGETS&apos;, value: PARAMETER_PLATFORM_TARGETS],
-                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IMAGE_TAG&apos;, value: job_number],
-                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IRODS_BUILD_DIR&apos;, value: buildOutputDirectory],
-                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_DATABASE_TYPE&apos;, value: PARAMETER_DATABASE_TYPE],
-                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_TEST_TYPE&apos;, value: &apos;topology_resource&apos;]
-            ]
-        }
-    }
-    if(PARAMETER_RUN_TOPOLOGY_RESOURCE_TESTS == &quot;true&quot; &amp;&amp; PARAMETER_ENABLE_SSL == &quot;true&quot;) {
-        stage(&quot;Install and Run Topology Tests With SSL on Consumer&quot;) {
+        stage(&quot;Install and Run Topology Tests&quot;) {
             build job:&quot;run_tests_on_topology&quot;,
             parameters: [
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_PLATFORM_TARGETS&apos;, value: PARAMETER_PLATFORM_TARGETS],
@@ -226,7 +226,21 @@
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IRODS_BUILD_DIR&apos;, value: buildOutputDirectory],
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_DATABASE_TYPE&apos;, value: PARAMETER_DATABASE_TYPE],
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_TEST_TYPE&apos;, value: &apos;topology_resource&apos;],
-                [$class: &apos;BooleanParameterValue&apos;, name: &apos;PARAMETER_ENABLE_SSL&apos;, value: PARAMETER_ENABLE_SSL]
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_MYSQL_ODBC_CONNECTOR_DIR&apos;, value: PARAMETER_MYSQL_ODBC_CONNECTOR_DIR]
+            ]
+        }
+    }
+    if(PARAMETER_RUN_TOPOLOGY_RESOURCE_TESTS == &quot;true&quot; &amp;&amp; PARAMETER_ENABLE_SSL == &quot;true&quot;) {
+        stage(&quot;Install and Run Topology Tests With SSL&quot;) {
+            build job:&quot;run_tests_on_topology&quot;,
+            parameters: [
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_PLATFORM_TARGETS&apos;, value: PARAMETER_PLATFORM_TARGETS],
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IMAGE_TAG&apos;, value: job_number],
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IRODS_BUILD_DIR&apos;, value: buildOutputDirectory],
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_DATABASE_TYPE&apos;, value: PARAMETER_DATABASE_TYPE],
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_TEST_TYPE&apos;, value: &apos;topology_resource&apos;],
+                [$class: &apos;BooleanParameterValue&apos;, name: &apos;PARAMETER_ENABLE_SSL&apos;, value: PARAMETER_ENABLE_SSL],
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_MYSQL_ODBC_CONNECTOR_DIR&apos;, value: PARAMETER_MYSQL_ODBC_CONNECTOR_DIR]
             ]
         }
     }


### PR DESCRIPTION
This change removes the volume mount for the file in RENCI's
/projects NFS mount. Now CI will pass the MySQL ODBC Connector
file locations as parameters which are then used by the scripts
to setup the MySQL client.

To change the default behavior, change the parameter for the job
being run called PARAMETER_MYSQL_ODBC_CONNECTOR_DIR to a location
accessible for read by the host machine. This will become a mount
point inside of the containers running tests. The location must have
a file corresponding to the filenames in the map in configuration.py
called mysql_odbc_connectors (there is one entry per supported platform).
If the file is called something different, or a different version is
desired, the filename string in the map should be changed to the
desired value.

---
This only affects ubuntu16/18. Core timing tests passed for both platforms, but I need to run basically all of the jobs before we merge this.