### PR TITLE
[#109] Start iRODS server after running setup script

### DIFF
--- a/irods_docker_files/ci_utilities.py
+++ b/irods_docker_files/ci_utilities.py
@@ -300,6 +300,12 @@ def upgrade(upgrade_packages_directory, database_type, database_machine, install
     stop_server(final_version)
     start_server(final_version)
 
+def start_server(irods_version):
+    if irods_version <= (4,1):
+        subprocess_get_output(['su', '-', 'irods', '-c', '/var/lib/irods/iRODS/irodsctl start'], check_rc=True)
+    else:
+        subprocess_get_output(['su', '-', 'irods', '-c', '/var/lib/irods/irodsctl start'], check_rc=True)
+
 def stop_server(irods_version):
     if irods_version <= (4,1):
         subprocess_get_output(['su', '-', 'irods', '-c', '/var/lib/irods/iRODS/irodsctl stop'], check_rc=True)

--- a/irods_docker_files/install_and_test.py
+++ b/irods_docker_files/install_and_test.py
@@ -127,6 +127,7 @@ def main():
 
     ci_utilities.install_irods_packages(args.database_type, args.database_machine, args.install_externals, get_irods_packages_directory(), get_externals_directory(), is_provider=True)
     ci_utilities.setup_irods(args.database_type, 'tempZone', args.database_machine)
+    ci_utilities.start_server(ci_utilities.get_irods_version())
 
     if args.upgrade_test:
         ci_utilities.upgrade(get_upgrade_packages_directory(), args.database_type, args.install_externals, get_externals_directory())


### PR DESCRIPTION
As of resolution of irods/irods#5275, the iRODS server is not running after the setup script is run. This change makes a call to start the server after the setup script returns.

Seems to work with timing tests. Waiting for them to complete. May be needed in other places (federation, topology, etc.)?