### PR TITLE
[#123] set PyOpenSSL and cryptography at last working versions

### DIFF
--- a/irods_docker_files/Dockerfile.ubuntu
+++ b/irods_docker_files/Dockerfile.ubuntu
@@ -26,8 +26,8 @@ RUN apt-get clean && \
 
 RUN apt-get install -y libffi-dev libssl-dev
 RUN python -m pip install -U setuptools
-RUN python -m easy_install --upgrade pyOpenSSL
-RUN python -m easy_install --upgrade cryptography
+RUN python -m easy_install --upgrade 'pyOpenSSL<=3.3.2'
+RUN python -m easy_install --upgrade 'cryptography<=3.3.2'
 RUN apt-get update
 
 RUN cd /tmp && git clone https://github.com/irods/irods_python_ci_utilities && \


### PR DESCRIPTION
The forward movement of pip package repositories is shifting quickly into a Python 3-centric vein, now that 2.7 is no longer supported, causing inconsistencies and hiccups to appear where none were previously.  This is just the latest on that front. 

