### PR TITLE
[#54] Separate unit tests pipeline step from core

### DIFF
--- a/irods_docker_files/run_tests.py
+++ b/irods_docker_files/run_tests.py
@@ -15,7 +15,7 @@ from docker_cmd_builder import DockerCommandsBuilder
 def get_test_name_prefix(base_os, prefix):
     test_name_prefix = base_os + '-' + prefix
 
-def run_tests(image_name, irods_sha, test_name_prefix, cmd_line_args, skip_unit_tests=False):
+def run_tests(image_name, irods_sha, test_name_prefix, cmd_line_args):
     # build options list for run_tests_in_parallel
     options = []
     options.append(['--image_name', image_name])
@@ -27,10 +27,10 @@ def run_tests(image_name, irods_sha, test_name_prefix, cmd_line_args, skip_unit_
     options.append(['--irods_commitish', irods_sha])
     options.append(['--test_parallelism', cmd_line_args.test_parallelism])
     options.append(['--externals_dir', cmd_line_args.externals_dir])
-    if skip_unit_tests is False:
-        options.append(['--is_unit_test'])
     if cmd_line_args.run_timing_tests:
         options.append(['--run_timing_tests'])
+    elif cmd_line_args.run_unit_tests:
+        options.append(['--is_unit_test'])
 
     run_tests_cmd_list = ['python', 'run_tests_in_parallel.py']
     for option in options:
@@ -95,7 +95,7 @@ def main():
     parser.add_argument('--test_parallelism', default='4', help='The number of tests to run in parallel', required=False)
     parser.add_argument('-o', '--output_directory', type=str, required=True)
     parser.add_argument('--passthrough_arguments', type=str)
-    parser.add_argument('--skip_unit_tests', action='store_true', default=False)
+    parser.add_argument('--run_unit_tests', action='store_true', default=False)
     parser.add_argument('--run_timing_tests', action='store_true', default=False)
     
     args = parser.parse_args()
@@ -112,7 +112,7 @@ def main():
 
     if not args.test_plugin:
         irods_sha = ci_utilities.get_sha_from_commitish(args.irods_repo, args.irods_commitish)
-        run_tests(build_tag, irods_sha, test_name_prefix, args, args.skip_unit_tests)
+        run_tests(build_tag, irods_sha, test_name_prefix, args)
     else:
         plugin_repo = args.plugin_repo
         plugin_repo_split = plugin_repo.split('/')

--- a/irods_docker_files/run_tests_in_parallel.py
+++ b/irods_docker_files/run_tests_in_parallel.py
@@ -138,15 +138,14 @@ def main():
 
     if args.run_timing_tests:
         test_list = ['timing_tests']
+        docker_cmds_list.extend(to_docker_commands(test_list, args))
+    elif args.is_unit_test:
+        test_list = download_list_of_tests(args.irods_repo, irods_sha, 'unit_tests/unit_tests_list.json')
+        docker_cmds_list.extend(to_docker_commands(test_list, args, args.is_unit_test))
     else:
-        if args.is_unit_test:
-            test_list = download_list_of_tests(args.irods_repo, irods_sha, 'unit_tests/unit_tests_list.json')
-            docker_cmds_list.extend(to_docker_commands(test_list, args, args.is_unit_test))
-
         # Add core-test commands to the list.
         test_list = download_list_of_tests(args.irods_repo, irods_sha, 'scripts/core_tests_list.json')
-
-    docker_cmds_list.extend(to_docker_commands(test_list, args))
+        docker_cmds_list.extend(to_docker_commands(test_list, args))
 
     run_pool = Pool(processes=int(args.test_parallelism))
     job_output_dir = generate_job_output_directory_path(args.jenkins_output, args.image_name)

--- a/jenkins_home/jobs/run_irods_tests/config.xml
+++ b/jenkins_home/jobs/run_irods_tests/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.1' encoding='UTF-8'?>
-<flow-definition plugin="workflow-job@2.36">
+<flow-definition plugin="workflow-job@2.40">
   <actions/>
   <description></description>
   <keepDependencies>false</keepDependencies>
@@ -71,7 +71,7 @@
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
-  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2.77">
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2.87">
     <script>node {
      def build_id = env.BUILD_ID
      print(build_id)
@@ -94,8 +94,8 @@
                               &apos; --irods_commitish &apos; + PARAMETER_IRODS_COMMITISH +
                               &apos; --test_parallelism &apos; + PARAMETER_TEST_PARALLELISM +
                               &apos; --externals_dir &apos; + PARAMETER_EXTERNALS_ROOT_DIR
-                if (PARAMETER_RUN_UNIT_TESTS == &quot;false&quot;) {
-                    run_cmd = run_cmd + &apos; --skip_unit_tests&apos;
+                if (PARAMETER_RUN_UNIT_TESTS == &quot;true&quot;) {
+                    run_cmd = run_cmd + &apos; --run_unit_tests&apos;
                 }
                 if (PARAMETER_RUN_CORE_TIMING_TESTS == &quot;true&quot;) {
                     run_cmd = run_cmd + &apos; --run_timing_tests&apos;

--- a/jenkins_home/jobs/serialized-irods-build-and-test-workflow/config.xml
+++ b/jenkins_home/jobs/serialized-irods-build-and-test-workflow/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.1' encoding='UTF-8'?>
-<flow-definition plugin="workflow-job@2.37">
+<flow-definition plugin="workflow-job@2.40">
   <actions/>
   <description></description>
   <keepDependencies>false</keepDependencies>
@@ -101,7 +101,7 @@
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
-  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2.80">
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2.87">
     <script>node {
     def job_number = env.BUILD_ID
     def buildOutputDirectory = env.JENKINS_OUTPUT + &apos;/build_irods_on_base/&apos; + job_number
@@ -136,9 +136,25 @@
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IRODS_COMMITISH&apos;, value: PARAMETER_IRODS_COMMITISH],
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_TEST_PARALLELISM&apos;, value: PARAMETER_TEST_PARALLELISM],
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_EXTERNALS_ROOT_DIR&apos;, value: PARAMETER_EXTERNALS_ROOT_DIR],
-                [$class: &apos;BooleanParameterValue&apos;, name: &apos;PARAMETER_RUN_CORE_TIMING_TESTS&apos;, value: PARAMETER_RUN_CORE_TIMING_TESTS]
+                [$class: &apos;BooleanParameterValue&apos;, name: &apos;PARAMETER_RUN_CORE_TIMING_TESTS&apos;, value: &quot;true&quot;]
             ]
         }
+    }
+    if(PARAMETER_RUN_CORE_UNIT_TESTS == &quot;true&quot;) {
+        stage(&quot;Install and Run iRODS Unit Tests&quot;) {
+            build job: &quot;run_irods_tests&quot;, 
+            parameters: [
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_PLATFORM_TARGETS&apos;, value: PARAMETER_PLATFORM_TARGETS], 
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IMAGE_TAG&apos;, value: job_number],
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IRODS_BUILD_DIR&apos;, value: buildOutputDirectory],
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_DATABASE_TYPE&apos;, value: PARAMETER_DATABASE_TYPE],
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IRODS_REPO&apos;, value: PARAMETER_IRODS_REPO],
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IRODS_COMMITISH&apos;, value: PARAMETER_IRODS_COMMITISH],
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_TEST_PARALLELISM&apos;, value: PARAMETER_TEST_PARALLELISM],
+                [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_EXTERNALS_ROOT_DIR&apos;, value: PARAMETER_EXTERNALS_ROOT_DIR],
+                [$class: &apos;BooleanParameterValue&apos;, name: &apos;PARAMETER_RUN_UNIT_TESTS&apos;, value: &quot;true&quot;]
+            ]
+        }    
     }
     if(PARAMETER_RUN_CORE_TESTS == &quot;true&quot;) {
         stage(&quot;Install and Run iRODS Core Tests&quot;) {
@@ -152,7 +168,7 @@
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IRODS_COMMITISH&apos;, value: PARAMETER_IRODS_COMMITISH],
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_TEST_PARALLELISM&apos;, value: PARAMETER_TEST_PARALLELISM],
                 [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_EXTERNALS_ROOT_DIR&apos;, value: PARAMETER_EXTERNALS_ROOT_DIR],
-                [$class: &apos;BooleanParameterValue&apos;, name: &apos;PARAMETER_RUN_UNIT_TESTS&apos;, value: PARAMETER_RUN_CORE_UNIT_TESTS]
+                [$class: &apos;BooleanParameterValue&apos;, name: &apos;PARAMETER_RUN_UNIT_TESTS&apos;, value: &quot;false&quot;]
             ]
         }    
     }


### PR DESCRIPTION
Makes unit tests run in a separate pipeline step from the core test
suite so that they can be run separately. More work is probably needed
to separate these test suites so they can be run more efficiently.