### PR TITLE
[_XXX] Remove stages from serialized plugin job

### DIFF
--- a/jenkins_home/jobs/serialized_all_plugins_build_and_test_workflow/config.xml
+++ b/jenkins_home/jobs/serialized_all_plugins_build_and_test_workflow/config.xml
@@ -1,10 +1,10 @@
 <?xml version='1.1' encoding='UTF-8'?>
-<flow-definition plugin="workflow-job@2.39">
+<flow-definition plugin="workflow-job@2.40">
   <actions/>
   <description></description>
   <keepDependencies>false</keepDependencies>
   <properties>
-    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.31">
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.32">
       <autoRebuild>false</autoRebuild>
       <rebuildDisabled>false</rebuildDisabled>
     </com.sonyericsson.rebuild.RebuildSettings>
@@ -12,14 +12,11 @@
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
           <name>PARAMETER_PLUGIN_GIT_COMMITISH</name>
-          <description></description>
           <defaultValue>master</defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>PARAMETER_IRODS_BUILD_DIR</name>
-          <description></description>
-          <defaultValue></defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
@@ -31,32 +28,18 @@
         <hudson.model.StringParameterDefinition>
           <name>PARAMETER_IMAGE_TAG</name>
           <description>this is either the job id or the tag for the base os images</description>
-          <defaultValue></defaultValue>
           <trim>true</trim>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>PARAMETER_DATABASE_TYPE</name>
-          <description></description>
           <defaultValue>postgres</defaultValue>
           <trim>false</trim>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
   </properties>
-  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2.80">
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2.90">
     <script>node {
-        stage(&apos;build_and_test_audit_amqp&apos;) {build job: &apos;amqp-audit-plugin-build-and-test-workflow&apos;,
-                              parameters: [[$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_PLUGIN_GIT_COMMITISH&apos;, value: PARAMETER_PLUGIN_GIT_COMMITISH],
-                                           [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_PLATFORM_TARGETS&apos;, value: PARAMETER_PLATFORM_TARGETS],
-                                           [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IMAGE_TAG&apos;, value: PARAMETER_IMAGE_TAG],
-                                           [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IRODS_BUILD_DIR&apos;, value: PARAMETER_IRODS_BUILD_DIR],
-                                           [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_DATABASE_TYPE&apos;, value: PARAMETER_DATABASE_TYPE]]}
-        stage(&apos;build_and_test_collection_mtime&apos;) {build job: &apos;collection-mtime-plugin-build-and-test-workflow&apos;,
-                              parameters: [[$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_PLUGIN_GIT_COMMITISH&apos;, value: PARAMETER_PLUGIN_GIT_COMMITISH],
-                                           [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_PLATFORM_TARGETS&apos;, value: PARAMETER_PLATFORM_TARGETS],
-                                           [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IMAGE_TAG&apos;, value: PARAMETER_IMAGE_TAG],
-                                           [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_IRODS_BUILD_DIR&apos;, value: PARAMETER_IRODS_BUILD_DIR],
-                                           [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_DATABASE_TYPE&apos;, value: PARAMETER_DATABASE_TYPE]]}
         stage(&apos;build_and_test_curl&apos;) {build job: &apos;curl-plugin-build-and-test-workflow&apos;,
                               parameters: [[$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_PLUGIN_GIT_COMMITISH&apos;, value: PARAMETER_PLUGIN_GIT_COMMITISH],
                                            [$class: &apos;StringParameterValue&apos;, name: &apos;PARAMETER_PLATFORM_TARGETS&apos;, value: PARAMETER_PLATFORM_TARGETS],


### PR DESCRIPTION
Removed updated_collection_mtime REP stage as this repository has been
archived in favor of the native support within the server.

Removed audit AMQP REP stage as this step is not serial and will fail as
a result.

---

Currently running... several stages have completed successfully so far.